### PR TITLE
allow for orderid > 9999

### DIFF
--- a/lib/cgiapps/stationery.class.php
+++ b/lib/cgiapps/stationery.class.php
@@ -1581,7 +1581,7 @@ function showFinal() {
     $handling_cost = '';
     $cost_price = '';
   }
-  $ordernumber = substr($job_name, 0, 4);
+  $ordernumber = substr($job_name, 0, strpos($job_name, '-'));
   $yaml_array =  array(
       'order number' => $ordernumber,
       'url' => $pdfurl,


### PR DESCRIPTION
Change order number calculation to look for first hyphen in job_name
instead of arbitrary 4 digits